### PR TITLE
Added hostinger's clientside origin to allowed origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -68,6 +68,7 @@ app = FastAPI(
 origins = [
     "http://127.0.0.1:3000",
     "http://127.0.0.1:3001",
+    "https://boredtap.com"
     "https://boredtap.netlify.app",
     "https://boredtapadmin.netlify.app",
     "https://boredtapadminproject.netlify.app",


### PR DESCRIPTION
updated allowed origins: clientside on hostinger now has access to boredtap's API.